### PR TITLE
Fix windows path handling for venv

### DIFF
--- a/lua/uv/init.lua
+++ b/lua/uv/init.lua
@@ -80,15 +80,16 @@ end
 
 -- Virtual environment activation
 function M.activate_venv(venv_path)
-	-- For Mac, run the source command to apply to the current shell
-	local command = "source " .. venv_path .. "/bin/activate"
-	-- Set environment variables for the current Neovim instance
-	vim.env.VIRTUAL_ENV = venv_path
-	vim.env.PATH = venv_path .. "/bin:" .. vim.env.PATH
-	-- Notify user
-	if M.config.notify_activate_venv then
-		vim.notify("Activated virtual environment: " .. venv_path, vim.log.levels.INFO)
-	end
+        local is_windows = package.config:sub(1, 1) == '\\'
+        local venv_dir = is_windows and 'Scripts' or 'bin'
+        local sep = is_windows and ';' or ':'
+
+        vim.env.VIRTUAL_ENV = venv_path
+        vim.env.PATH = venv_path .. '/' .. venv_dir .. sep .. vim.env.PATH
+
+        if M.config.notify_activate_venv then
+                vim.notify("Activated virtual environment: " .. venv_path, vim.log.levels.INFO)
+        end
 end
 
 -- Auto-activate the .venv if it exists at the project root


### PR DESCRIPTION
## Summary
- use platform specific path separators and virtual env folder when activating venvs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886314831d48320b615f1576bdacdd8